### PR TITLE
Add next page button to chrome extension installation page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vibinex-website",
-	"version": "1.2.3",
+	"version": "1.2.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vibinex-website",
-			"version": "1.2.3",
+			"version": "1.2.4",
 			"license": "LGPL-3.0-or-later",
 			"dependencies": {
 				"@formatjs/intl-localematcher": "^0.5.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vibinex-website",
-	"version": "1.2.3",
+	"version": "1.2.4",
 	"private": false,
 	"homepage": "https://vibinex.com",
 	"description": "A plugin that works with GitHub, Bitbucket and GitLab to personalize and data-enrich their code review interfaces",

--- a/pages/docs/setup/chromeExtension.tsx
+++ b/pages/docs/setup/chromeExtension.tsx
@@ -10,6 +10,7 @@ import { getAndSetAnonymousIdFromLocalStorage } from '../../../utils/rudderstack
 import { Theme, getPreferredTheme } from '../../../utils/theme';
 import MainAppBar from '../../../views/MainAppBar';
 import DocsSideBar from '../../../views/docs/DocsSideBar';
+import { getURLWithParams } from "../../../utils/url_utils";
 
 const ChromeExtension: React.FC = () => {
     const [session, setSession] = useState<Session | null>(null);
@@ -56,6 +57,15 @@ The chrome extension enables highlights for your pull requests.
                             className='px-4 py-2 mt-4'
                         >
                         Install Vibinex Chrome Extension   
+                        </Button>
+                    </div>
+                    <div className="absolute bottom-0 right-0 mb-8 mr-2">
+                        <Button
+                            href={getURLWithParams('/u', {})}
+                            variant="contained"
+                            className='px-4 py-2 flex-1 sm:flex-grow-0'
+                        >
+                            Next &raquo;
                         </Button>
                     </div>
                 </div>


### PR DESCRIPTION
- [x] locally tested

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a button in the Chrome Extension setup page for easier navigation to specified URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->