### PR TITLE
build fix: GCP build not working because of rudderstack module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
 				"@radix-ui/react-tabs": "^1.0.4",
 				"@radix-ui/react-toast": "^1.1.5",
 				"@radix-ui/themes": "^2.0.2",
-				"@rudderstack/rudder-sdk-node": "^2.0.2",
+				"@rudderstack/rudder-sdk-node": "2.0.2",
 				"@sendgrid/mail": "^8.1.3",
 				"@types/mdx": "^2.0.5",
 				"@types/node": "18.11.14",
@@ -57,7 +57,7 @@
 				"react-markdown": "^9.0.1",
 				"react-slideshow-image": "^4.3.1",
 				"remark-gfm": "^4.0.0",
-				"rudder-sdk-js": "^2.25.0",
+				"rudder-sdk-js": "2.25.0",
 				"sharp": "^0.32.6",
 				"typescript": "4.9.4",
 				"uuid": "^9.0.0"
@@ -795,6 +795,24 @@
 			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true
+		},
+		"node_modules/@colors/colors": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+			"integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+			"engines": {
+				"node": ">=0.1.90"
+			}
+		},
+		"node_modules/@dabh/diagnostics": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
+			"integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
+			"dependencies": {
+				"colorspace": "1.1.x",
+				"enabled": "2.0.x",
+				"kuler": "^2.0.0"
+			}
 		},
 		"node_modules/@eslint/eslintrc": {
 			"version": "1.4.1",
@@ -1812,25 +1830,6 @@
 				"node": ">=v12.0.0"
 			}
 		},
-		"node_modules/@lukeed/csprng": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
-			"integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@lukeed/uuid": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.1.tgz",
-			"integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
-			"dependencies": {
-				"@lukeed/csprng": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/@mdx-js/loader": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/@mdx-js/loader/-/loader-2.3.0.tgz",
@@ -1902,38 +1901,6 @@
 			"os": [
 				"linux"
 			]
-		},
-		"node_modules/@ndhoule/defaults": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@ndhoule/defaults/-/defaults-2.0.1.tgz",
-			"integrity": "sha512-wwuxdvaTbgw9mmeZ516RQWx9V+ToC+B6t3g+eM/CgzXsf+JLvunLd9WOn9yHP4tzxV6nDDTx8fEwhU+xWsX4tA==",
-			"dependencies": {
-				"@ndhoule/drop": "^2.0.0",
-				"@ndhoule/rest": "^2.0.0"
-			}
-		},
-		"node_modules/@ndhoule/drop": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@ndhoule/drop/-/drop-2.0.0.tgz",
-			"integrity": "sha512-vtVA2bqlzvYhwjxbKUYbGM8Ouba4n3cXKWbDyLaZldjUPQ2Mlizv3LR1J7qqRVTUpxZj41vUOQwqXdocrCrWzw=="
-		},
-		"node_modules/@ndhoule/each": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@ndhoule/each/-/each-2.0.1.tgz",
-			"integrity": "sha512-wHuJw6x+rF6Q9Skgra++KccjBozCr9ymtna0FhxmV/8xT/hZ2ExGYR8SV8prg8x4AH/7mzDYErNGIVHuzHeybw==",
-			"dependencies": {
-				"@ndhoule/keys": "^2.0.0"
-			}
-		},
-		"node_modules/@ndhoule/keys": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@ndhoule/keys/-/keys-2.0.0.tgz",
-			"integrity": "sha512-vtCqKBC1Av6dsBA8xpAO+cgk051nfaI+PnmTZep2Px0vYrDvpUmLxv7z40COlWH5yCpu3gzNhepk+02yiQiZNw=="
-		},
-		"node_modules/@ndhoule/rest": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@ndhoule/rest/-/rest-2.0.0.tgz",
-			"integrity": "sha512-oBzJczbr6E/McwdSYWzOJvIcIFvLDHM0NHct+B2T7RQStpLMP+H4ay4kzxk0Wts8MaLw5BSRxxelAhWERRol3w=="
 		},
 		"node_modules/@next/env": {
 			"version": "13.3.1",
@@ -2337,15 +2304,6 @@
 			"integrity": "sha512-dhPeilub1NuIG0X5Kvhh9lH4iW3ZsHlnzwgwbOlgwQ2wG1IqFzsgHqmKPk3WzsdWAeaxKJxgM0+W433RmN45GA==",
 			"funding": {
 				"url": "https://github.com/sponsors/panva"
-			}
-		},
-		"node_modules/@preact/signals-core": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.4.0.tgz",
-			"integrity": "sha512-5iYoZBhELLIhUQceZI7sDTQWPb+xcVSn2qk8T/aNl/VMh+A4AiPX9YRSh4XO7fZ6pncrVxl1Iln82poVqYVbbw==",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/preact"
 			}
 		},
 		"node_modules/@protobufjs/aspromise": {
@@ -3762,45 +3720,28 @@
 				"react-dom": "^16.8.0  || >=17.0.0 || >=18.0.0"
 			}
 		},
-		"node_modules/@rudderstack/analytics-js-common": {
-			"version": "3.0.0-beta.9",
-			"resolved": "https://registry.npmjs.org/@rudderstack/analytics-js-common/-/analytics-js-common-3.0.0-beta.9.tgz",
-			"integrity": "sha512-IX0/Fuck4ZvEEvvDFH609f2FwOZPK+WqZvqm8GWFVzKdOT4xWz4hgFff+G4k+HZdhARLbMkNuWPDysdbmf61ng==",
-			"dependencies": {
-				"@lukeed/uuid": "2.0.1",
-				"@ndhoule/defaults": "2.0.1",
-				"@preact/signals-core": "1.4.0",
-				"@segment/top-domain": "3.0.1",
-				"crypto-js": "4.1.1",
-				"get-value": "3.0.1",
-				"ramda": "0.29.0",
-				"rudder-component-cookie": "0.0.1",
-				"storejs": "2.0.6"
-			}
-		},
 		"node_modules/@rudderstack/rudder-sdk-node": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@rudderstack/rudder-sdk-node/-/rudder-sdk-node-2.0.5.tgz",
-			"integrity": "sha512-LjkI/Lx1sbY1OU8njJVJQudXZFxVLo3gq7ib6dAyYGkn+gpMhDlMtNRm1F6P8hlDkzJv/DBo7fmWCivfg8JqcQ==",
-			"hasInstallScript": true,
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@rudderstack/rudder-sdk-node/-/rudder-sdk-node-2.0.2.tgz",
+			"integrity": "sha512-6HRSqySqiH2WnEPJBUMU6SBo/nCzvMaShr4dnrYhjRqNfcnvEWBTRFqtIRklIhBzOO1xaOcFvJIEwZktv1pzEw==",
 			"dependencies": {
+				"@segment/loosely-validate-event": "^2.0.0",
 				"axios": "0.26.0",
-				"axios-retry": "3.7.0",
-				"component-type": "1.2.1",
-				"join-component": "1.1.0",
-				"lodash.clonedeep": "4.5.0",
-				"lodash.isstring": "4.0.1",
-				"md5": "2.3.0",
-				"ms": "2.1.3",
-				"remove-trailing-slash": "0.1.1",
-				"serialize-javascript": "6.0.1",
-				"uuid": "8.3.2"
+				"axios-retry": "^3.2.4",
+				"lodash.clonedeep": "^4.5.0",
+				"lodash.isstring": "^4.0.1",
+				"md5": "^2.3.0",
+				"ms": "^2.1.3",
+				"remove-trailing-slash": "^0.1.1",
+				"serialize-javascript": "^6.0.0",
+				"uuid": "^8.3.2",
+				"winston": "^3.6.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=4"
 			},
 			"optionalDependencies": {
-				"bull": "4.11.3"
+				"bull": "^4.10.2"
 			}
 		},
 		"node_modules/@rudderstack/rudder-sdk-node/node_modules/axios": {
@@ -3824,26 +3765,6 @@
 			"resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.4.0.tgz",
 			"integrity": "sha512-cEjvTPU32OM9lUFegJagO0mRnIn+rbqrG89vV8/xLnLFX0DoR0r1oy5IlTga71Q7uT3Qus7qm7wgeiMT/+Irlg=="
 		},
-		"node_modules/@segment/localstorage-retry": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@segment/localstorage-retry/-/localstorage-retry-1.3.0.tgz",
-			"integrity": "sha512-myp6eh0J+2Zj+lBi1tTa5LAaudPLOfS7H1rlx0F2vx/IROyI8A3bli2HISVhuTy7AeSqSZIVkfma/UQCOj8zxg==",
-			"dependencies": {
-				"@lukeed/uuid": "^2.0.0",
-				"@ndhoule/each": "^2.0.1",
-				"@ndhoule/keys": "^2.0.0",
-				"component-emitter": "^1.2.1",
-				"debug": "^0.7.4"
-			}
-		},
-		"node_modules/@segment/localstorage-retry/node_modules/debug": {
-			"version": "0.7.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-			"integrity": "sha512-EohAb3+DSHSGx8carOSKJe8G0ayV5/i609OD0J2orCkuyae7SyZSz2aoLmQF2s0Pj5gITDebwPH7GFBlqOUQ1Q==",
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/@segment/loosely-validate-event": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
@@ -3851,15 +3772,6 @@
 			"dependencies": {
 				"component-type": "^1.2.1",
 				"join-component": "^1.1.0"
-			}
-		},
-		"node_modules/@segment/top-domain": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@segment/top-domain/-/top-domain-3.0.1.tgz",
-			"integrity": "sha512-A8E80WlV0IXLQZ+keBiv/6yMmwW2pzXaiCcY/TUEBOAhO1kPj8PFLJC17uuN8nqxKv0rIkRGeBIgslMMT3uNfQ==",
-			"dependencies": {
-				"component-cookie": "^1.1.5",
-				"component-url": "^0.2.1"
 			}
 		},
 		"node_modules/@sendgrid/client": {
@@ -4428,6 +4340,11 @@
 			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.3.tgz",
 			"integrity": "sha512-THo502dA5PzG/sfQH+42Lw3fvmYkceefOspdCwpHRul8ik2Jv1K8I5OZz1AT3/rs46kwgMCe9bSBmDLYkkOMGg=="
 		},
+		"node_modules/@types/triple-beam": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+			"integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
+		},
 		"node_modules/@types/unist": {
 			"version": "2.0.8",
 			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.8.tgz",
@@ -4554,14 +4471,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
 			"integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
-		},
-		"node_modules/@vespaiach/axios-fetch-adapter": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/@vespaiach/axios-fetch-adapter/-/axios-fetch-adapter-0.3.1.tgz",
-			"integrity": "sha512-+1F52VWXmQHSRFSv4/H0wtnxfvjRMPK5531e880MIjypPdUSX6QZuoDgEVeCE1vjhzDdxCVX7rOqkub7StEUwQ==",
-			"peerDependencies": {
-				"axios": ">=0.26.0"
-			}
 		},
 		"node_modules/@webassemblyjs/ast": {
 			"version": "1.11.6",
@@ -5049,17 +4958,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/assert": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
-			"integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
-			"dependencies": {
-				"es6-object-assign": "^1.1.0",
-				"is-nan": "^1.2.1",
-				"object-is": "^1.0.1",
-				"util": "^0.12.0"
-			}
-		},
 		"node_modules/ast-types-flow": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
@@ -5072,6 +4970,11 @@
 			"bin": {
 				"astring": "bin/astring"
 			}
+		},
+		"node_modules/async": {
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+			"integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
 		},
 		"node_modules/async-retry": {
 			"version": "1.3.3",
@@ -5853,6 +5756,37 @@
 				"simple-swizzle": "^0.2.2"
 			}
 		},
+		"node_modules/colorspace": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
+			"integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
+			"dependencies": {
+				"color": "^3.1.3",
+				"text-hex": "1.0.x"
+			}
+		},
+		"node_modules/colorspace/node_modules/color": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+			"integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+			"dependencies": {
+				"color-convert": "^1.9.3",
+				"color-string": "^1.6.0"
+			}
+		},
+		"node_modules/colorspace/node_modules/color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dependencies": {
+				"color-name": "1.1.3"
+			}
+		},
+		"node_modules/colorspace/node_modules/color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -5882,41 +5816,10 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/component-cookie": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/component-cookie/-/component-cookie-1.1.5.tgz",
-			"integrity": "sha512-+D1nKIL6UfbYBoUeHVVdmd+I+BhgjjMQtT5cHp7HLAdpVi+7GZSvbYPItYaNgTeta5znlC8PJsBFZSY1mf57ZA==",
-			"dependencies": {
-				"debug": "^2.6.9"
-			}
-		},
-		"node_modules/component-cookie/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/component-cookie/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-		},
-		"node_modules/component-emitter": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-			"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
-		},
 		"node_modules/component-type": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/component-type/-/component-type-1.2.1.tgz",
 			"integrity": "sha512-Kgy+2+Uwr75vAi6ChWXgHuLvd+QLD7ssgpaRq2zCvt80ptvAfMc/hijcJxXkBa2wMlEZcJvC2H8Ubo+A9ATHIg=="
-		},
-		"node_modules/component-url": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/component-url/-/component-url-0.2.1.tgz",
-			"integrity": "sha512-ThaWgt9+hMAsJj6FdfM+eT3Pvv5pkqgQpnxW9loVkS7tKbBtYPGgNq6c+ftxIgKt3rd04kHsiTXRyOz/Mdi14A=="
 		},
 		"node_modules/compressible": {
 			"version": "2.0.18",
@@ -6025,11 +5928,6 @@
 			"engines": {
 				"node": "*"
 			}
-		},
-		"node_modules/crypto-js": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
-			"integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
 		},
 		"node_modules/css.escape": {
 			"version": "1.5.1",
@@ -6551,6 +6449,11 @@
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
 			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
 		},
+		"node_modules/enabled": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+			"integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
+		},
 		"node_modules/encoding": {
 			"version": "0.1.13",
 			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
@@ -6761,11 +6664,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/es6-object-assign": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
-			"integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw=="
 		},
 		"node_modules/es6-promise": {
 			"version": "4.2.8",
@@ -7506,6 +7404,11 @@
 				"bser": "2.1.1"
 			}
 		},
+		"node_modules/fecha": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+			"integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
+		},
 		"node_modules/file-entry-cache": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -7560,6 +7463,11 @@
 			"version": "3.2.9",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
 			"integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ=="
+		},
+		"node_modules/fn.name": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+			"integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
 		},
 		"node_modules/follow-redirects": {
 			"version": "1.15.6",
@@ -7783,17 +7691,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-			}
-		},
-		"node_modules/get-value": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/get-value/-/get-value-3.0.1.tgz",
-			"integrity": "sha512-mKZj9JLQrwMBtj5wxi6MH8Z5eSKaERpAwjg43dPtlGI1ZVEgH/qC7T8/6R2OBSUA+zzHBZgICsVJaEIV2tKTDA==",
-			"dependencies": {
-				"isobject": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=6.0"
 			}
 		},
 		"node_modules/github-from-package": {
@@ -9079,14 +8976,6 @@
 				"url": "https://opencollective.com/ioredis"
 			}
 		},
-		"node_modules/is": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
-			"integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg==",
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/is-alphabetical": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
@@ -9113,6 +9002,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
 			"integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"has-tostringtag": "^1.0.0"
@@ -9319,21 +9209,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
 			"integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-nan": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
-			"integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
-			"dependencies": {
-				"call-bind": "^1.0.0",
-				"define-properties": "^1.1.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -9547,14 +9422,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
-		},
-		"node_modules/isobject": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-			"integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/istanbul-lib-coverage": {
 			"version": "3.2.0",
@@ -10983,6 +10850,11 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/kuler": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+			"integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
+		},
 		"node_modules/language-subtag-registry": {
 			"version": "0.3.22",
 			"resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.22.tgz",
@@ -11104,6 +10976,22 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
 			"integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
+		},
+		"node_modules/logform": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/logform/-/logform-2.6.1.tgz",
+			"integrity": "sha512-CdaO738xRapbKIMVn2m4F6KTj4j7ooJ8POVnebSgKo3KBz5axNXRAL7ZdRjIV6NOr2Uf4vjtRkxrFETOioCqSA==",
+			"dependencies": {
+				"@colors/colors": "1.6.0",
+				"@types/triple-beam": "^1.3.2",
+				"fecha": "^4.2.0",
+				"ms": "^2.1.1",
+				"safe-stable-stringify": "^2.3.1",
+				"triple-beam": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
 		},
 		"node_modules/long": {
 			"version": "5.2.3",
@@ -16340,6 +16228,7 @@
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
 			"integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3"
@@ -16464,6 +16353,14 @@
 			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
 			"dependencies": {
 				"wrappy": "1"
+			}
+		},
+		"node_modules/one-time": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+			"integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+			"dependencies": {
+				"fn.name": "1.x.x"
 			}
 		},
 		"node_modules/onetime": {
@@ -17540,15 +17437,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
 			"integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag=="
-		},
-		"node_modules/ramda": {
-			"version": "0.29.0",
-			"resolved": "https://registry.npmjs.org/ramda/-/ramda-0.29.0.tgz",
-			"integrity": "sha512-BBea6L67bYLtdbOqfp8f58fPMqEwx0doL+pAi8TZyp2YWz8R9G8z9x75CZI8W+ftqhFHCpEX2cRnUUXK130iKA==",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/ramda"
-			}
 		},
 		"node_modules/randombytes": {
 			"version": "2.1.0",
@@ -19520,57 +19408,11 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/rudder-component-cookie": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/rudder-component-cookie/-/rudder-component-cookie-0.0.1.tgz",
-			"integrity": "sha512-7dDFnpMLt/8cm2kxRPXKf03UWrB8IP4baY//95AFXRIgE8ykcwUPCrPka5DqlA6S1uIKvxV+mJkb5hJ1ND9Bgg==",
-			"dependencies": {
-				"debug": "2.2.0"
-			}
-		},
-		"node_modules/rudder-component-cookie/node_modules/debug": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-			"integrity": "sha512-X0rGvJcskG1c3TgSCPqHJ0XJgwlcvOC7elJ5Y0hYuKBZoVqWpAMfLOeIh2UI/DCQ5ruodIjvsugZtjUYUw2pUw==",
-			"dependencies": {
-				"ms": "0.7.1"
-			}
-		},
-		"node_modules/rudder-component-cookie/node_modules/ms": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-			"integrity": "sha512-lRLiIR9fSNpnP6TC4v8+4OU7oStC01esuNowdQ34L+Gk8e5Puoc88IqJ+XAY/B3Mn2ZKis8l8HX90oU8ivzUHg=="
-		},
 		"node_modules/rudder-sdk-js": {
-			"version": "2.42.2",
-			"resolved": "https://registry.npmjs.org/rudder-sdk-js/-/rudder-sdk-js-2.42.2.tgz",
-			"integrity": "sha512-nsv+ZQZD87Og/T8XI6H6HscpjJpgir7sdDcnpWNMjzb1gkhSQ9sJyA8LNhSNnI6c9+2a8WEckXCwSiITqZJWcA==",
-			"dependencies": {
-				"@lukeed/uuid": "2.0.1",
-				"@rudderstack/analytics-js-common": "3.0.0-beta.9",
-				"@segment/localstorage-retry": "1.3.0",
-				"@segment/loosely-validate-event": "2.0.0",
-				"@vespaiach/axios-fetch-adapter": "0.3.1",
-				"assert": "2.0.0",
-				"axios": "0.27.2",
-				"axios-retry": "3.7.0",
-				"component-emitter": "1.3.0",
-				"get-value": "3.0.1",
-				"is": "3.3.0",
-				"lodash.clonedeep": "4.5.0",
-				"lodash.isstring": "4.0.1",
-				"ms": "2.1.3",
-				"ramda": "0.29.0"
-			}
-		},
-		"node_modules/rudder-sdk-js/node_modules/axios": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-			"integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-			"dependencies": {
-				"follow-redirects": "^1.14.9",
-				"form-data": "^4.0.0"
-			}
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/rudder-sdk-js/-/rudder-sdk-js-2.25.0.tgz",
+			"integrity": "sha512-M9eE0uepjnN4CkO+icQtXGVvlTWfOrhubcbsQJ511WRFgp2Fy5CxlLKgdfTXpjqGYhaIKPG3vXrtKHQNhJfxRQ==",
+			"deprecated": "This package is deprecated. Please switch to the latest @rudderstack/analytics-js package for improved features and support. For more details visit, https://www.rudderstack.com/docs/sources/event-streams/sdks/rudderstack-javascript-sdk/."
 		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
@@ -19652,6 +19494,14 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/safe-stable-stringify": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+			"integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/safer-buffer": {
@@ -19941,6 +19791,14 @@
 			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
 			"dev": true
 		},
+		"node_modules/stack-trace": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+			"integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/stack-utils": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -19979,11 +19837,6 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
-		},
-		"node_modules/storejs": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/storejs/-/storejs-2.0.6.tgz",
-			"integrity": "sha512-JcznOtEe10w3A0UdaltC1+fR9/x2uEBDTzrxsyUWpIadueYorWAClQjXoQGZhR/q+/584nIN3mIp9olf3Yefow=="
 		},
 		"node_modules/stream-events": {
 			"version": "1.0.5",
@@ -20490,6 +20343,11 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/text-hex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+			"integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+		},
 		"node_modules/text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -20592,6 +20450,14 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/triple-beam": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+			"integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+			"engines": {
+				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/trough": {
@@ -21047,18 +20913,6 @@
 				}
 			}
 		},
-		"node_modules/util": {
-			"version": "0.12.5",
-			"resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-			"integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"is-arguments": "^1.0.4",
-				"is-generator-function": "^1.0.7",
-				"is-typed-array": "^1.1.3",
-				"which-typed-array": "^1.1.2"
-			}
-		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -21418,6 +21272,40 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/winston": {
+			"version": "3.14.2",
+			"resolved": "https://registry.npmjs.org/winston/-/winston-3.14.2.tgz",
+			"integrity": "sha512-CO8cdpBB2yqzEf8v895L+GNKYJiEq8eKlHU38af3snQBQ+sdAIUepjMSguOIJC7ICbzm0ZI+Af2If4vIJrtmOg==",
+			"dependencies": {
+				"@colors/colors": "^1.6.0",
+				"@dabh/diagnostics": "^2.0.2",
+				"async": "^3.2.3",
+				"is-stream": "^2.0.0",
+				"logform": "^2.6.0",
+				"one-time": "^1.0.0",
+				"readable-stream": "^3.4.0",
+				"safe-stable-stringify": "^2.3.1",
+				"stack-trace": "0.0.x",
+				"triple-beam": "^1.3.0",
+				"winston-transport": "^4.7.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/winston-transport": {
+			"version": "4.7.1",
+			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.7.1.tgz",
+			"integrity": "sha512-wQCXXVgfv/wUPOfb2x0ruxzwkcZfxcktz6JIMUaPLmcNhO4bZTwA/WtDWK74xV3F2dKu8YadrFv0qhwYjVEwhA==",
+			"dependencies": {
+				"logform": "^2.6.1",
+				"readable-stream": "^3.6.2",
+				"triple-beam": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
 			}
 		},
 		"node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"@radix-ui/react-tabs": "^1.0.4",
 		"@radix-ui/react-toast": "^1.1.5",
 		"@radix-ui/themes": "^2.0.2",
-		"@rudderstack/rudder-sdk-node": "^2.0.2",
+		"@rudderstack/rudder-sdk-node": "2.0.2",
 		"@sendgrid/mail": "^8.1.3",
 		"@types/mdx": "^2.0.5",
 		"@types/node": "18.11.14",
@@ -62,7 +62,7 @@
 		"react-markdown": "^9.0.1",
 		"react-slideshow-image": "^4.3.1",
 		"remark-gfm": "^4.0.0",
-		"rudder-sdk-js": "^2.25.0",
+		"rudder-sdk-js": "2.25.0",
 		"sharp": "^0.32.6",
 		"typescript": "4.9.4",
 		"uuid": "^9.0.0"


### PR DESCRIPTION
Using the fix version instead of the latest `^` version in the `package.json` file for a temporary fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated dependency versioning to use exact versions for improved stability and predictability in builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->