### PR TITLE
Fix multiline copy for docker instructions

### DIFF
--- a/components/setup/CodeWithCopyButton.tsx
+++ b/components/setup/CodeWithCopyButton.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import { MdContentCopy } from "react-icons/md";
 import Markdown from 'react-markdown';
@@ -12,10 +12,10 @@ const CodeWithCopyButton: React.FC<CodeWithCopyButtonProps> = ({ text }) => {
 	const [isCopied, setIsCopied] = useState<boolean>(false);
 	const [isButtonDisabled, setIsButtonDisabled] = useState<boolean>(false);
 
-	// Function to clean up the text before copying
+	// Function to clean up the text before displaying
 	const cleanUpText = (text: string) => {
-		// Replace multiple newlines with a single newline
-		return text.replace(/\n{2,}/g, '\n');
+		// Make sure that backslashes are properly escaped for Markdown
+		return text.replace(/\\/g, '\\\\');
 	};
 
 	const handleCopyClick = () => {
@@ -27,12 +27,25 @@ const CodeWithCopyButton: React.FC<CodeWithCopyButtonProps> = ({ text }) => {
 		setIsButtonDisabled(false);
 	};
 
+	useEffect(() => {
+ 		let timer: NodeJS.Timeout;
+ 		if (isCopied) {
+ 			timer = setTimeout(() => {
+ 				setIsCopied(false);
+				setIsButtonDisabled(false);
+ 			}, 2000); // Reset after 2 seconds
+ 		}
+ 		return () => clearTimeout(timer);
+ 	}, [isCopied]);
+ 
 	return (
 		<div className='relative border p-4 my-4'>
-			<Markdown remarkPlugins={[remarkGfm]}>
-				{text}
-			</Markdown>
-			<CopyToClipboard text={cleanUpText(text)} onCopy={handleCopy}>
+			<pre style={{ whiteSpace: 'pre-wrap' }}>
+				<Markdown remarkPlugins={[remarkGfm]}>
+					{cleanUpText(text)}
+				</Markdown>
+			</pre>
+			<CopyToClipboard text={text} onCopy={handleCopy}>
 				<button
 					className="absolute top-0 right-0 p-1 cursor-pointer bg-transparent border-none"
 					onClick={handleCopyClick}

--- a/components/setup/CodeWithCopyButton.tsx
+++ b/components/setup/CodeWithCopyButton.tsx
@@ -11,7 +11,13 @@ interface CodeWithCopyButtonProps {
 const CodeWithCopyButton: React.FC<CodeWithCopyButtonProps> = ({ text }) => {
 	const [isCopied, setIsCopied] = useState<boolean>(false);
 	const [isButtonDisabled, setIsButtonDisabled] = useState<boolean>(false);
-	
+
+	// Function to clean up the text before copying
+	const cleanUpText = (text: string) => {
+		// Replace multiple newlines with a single newline
+		return text.replace(/\n{2,}/g, '\n');
+	};
+
 	const handleCopyClick = () => {
 		setIsButtonDisabled(true);
 	};
@@ -26,9 +32,9 @@ const CodeWithCopyButton: React.FC<CodeWithCopyButtonProps> = ({ text }) => {
 			<Markdown remarkPlugins={[remarkGfm]}>
 				{text}
 			</Markdown>
-			<CopyToClipboard text={text} onCopy={handleCopy}>
+			<CopyToClipboard text={cleanUpText(text)} onCopy={handleCopy}>
 				<button
-		          	className="absolute top-0 right-0 p-1 cursor-pointer bg-transparent border-none"
+					className="absolute top-0 right-0 p-1 cursor-pointer bg-transparent border-none"
 					onClick={handleCopyClick}
 					disabled={isButtonDisabled}
 				>

--- a/components/setup/DockerInstructions.tsx
+++ b/components/setup/DockerInstructions.tsx
@@ -15,15 +15,10 @@ interface DockerInstructionsProps {
 const DockerInstructions: React.FC<DockerInstructionsProps> = ({ selectedInstallationType, selectedProvider, installId }) => {
 	const selfHostingCode = `
 docker run \\
-
 -v ~/.config/vibinex:/app/config \\
-
 -e INSTALL_ID=${installId} \\
-
 ${selectedProvider === 'github' && selectedInstallationType === 'pat' ? `-e PROVIDER=github \\
-
 -e GITHUB_PAT=<Your gh cli token> \\
-
 ` : ''}asia.gcr.io/vibi-prod/dpu/dpu
   `;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vibinex-website",
-	"version": "1.2.12",
+	"version": "1.2.13",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vibinex-website",
-			"version": "1.2.12",
+			"version": "1.2.13",
 			"license": "LGPL-3.0-or-later",
 			"dependencies": {
 				"@formatjs/intl-localematcher": "^0.5.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vibinex-website",
-	"version": "1.2.12",
+	"version": "1.2.13",
 	"private": false,
 	"homepage": "https://vibinex.com",
 	"description": "A plugin that works with GitHub, Bitbucket and GitLab to personalize and data-enrich their code review interfaces",


### PR DESCRIPTION
### Bug
For multiline code in the docs, when the user copies the contents, they see extra newline characters in the command, which means the command does not work on directly pasting.

### Resolution
Modified the `CodeWithCopyButton` component such that it displays the text exactly as it is provided. This way, the default copy functionality also works as expected.

#### Side-effects
As a result, we now don't need the extra newline characters in the docker-instructions component, which were earlier added to make sure that the code is displayed correctly.

#### Additional feature
Improved the responsiveness of the copy button for subsequent button presses. Earlier, once the button was pressed, the feedback was constantly displayed on the screen. And if the user clicked on the button again, there was no feedback about whether or not was the text correctly copied to the clipboard.